### PR TITLE
fix(formatter): ajoute une clé embedCode dans les metadata

### DIFF
--- a/lib/formatter.js
+++ b/lib/formatter.js
@@ -19,7 +19,7 @@ var formatVideo = function formatVideo(providerName, videoId, _ref) {
     thumbnailUrl: thumbnailUrl,
     playerUrl: playerUrl,
     duration: formatDuration(duration),
-    metadata: '<iframe src=' + playerUrl + ' frameborder="0"></iframe>',
+    metadata: { embedCode: '<iframe src=' + playerUrl + ' frameborder="0"></iframe>' },
     provider: providerName,
     providerVideoId: videoId
   };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "universal-video-provider",
-  "version": "0.4.0",
+  "version": "0.4.1",
   "description": "es6 client and node universal video provider",
   "main": "index.js",
   "scripts": {

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -17,7 +17,7 @@ const formatVideo = (
   thumbnailUrl,
   playerUrl,
   duration: formatDuration(duration),
-  metadata: `<iframe src=${playerUrl} frameborder="0"></iframe>`,
+  metadata: { embedCode: `<iframe src=${playerUrl} frameborder="0"></iframe>` },
   provider: providerName,
   providerVideoId: videoId,
 });

--- a/test/formatter.js
+++ b/test/formatter.js
@@ -29,7 +29,7 @@ describe('Formatter', () => {
         duration: '01:08',
         thumbnailUrl: 'mythumbnailUrl',
         playerUrl: 'myplayerUrl',
-        metadata: '<iframe src=myplayerUrl frameborder="0"></iframe>',
+        metadata: { embedCode: '<iframe src=myplayerUrl frameborder="0"></iframe>' },
         provider: 'digiteka',
         providerVideoId: '123aze'
       });

--- a/test/provider.js
+++ b/test/provider.js
@@ -72,7 +72,7 @@ describe('Provider', () => {
           duration: '00:55',
           thumbnailUrl: 'dailymotion:thumbnailUrl',
           playerUrl: 'dailymotion:playerUrl',
-          metadata: '<iframe src=dailymotion:playerUrl frameborder="0"></iframe>',
+          metadata: { embedCode: '<iframe src=dailymotion:playerUrl frameborder="0"></iframe>' },
           provider: 'dailymotion',
           providerVideoId: '10'
         });
@@ -93,7 +93,7 @@ describe('Provider', () => {
           duration: '00:55',
           thumbnailUrl: 'dailymotion:thumbnailUrl',
           playerUrl: 'dailymotion:playerUrl',
-          metadata: '<iframe src=dailymotion:playerUrl frameborder="0"></iframe>',
+          metadata: { embedCode: '<iframe src=dailymotion:playerUrl frameborder="0"></iframe>' },
           provider: 'dailymotion',
           providerVideoId: '10'
         });
@@ -112,7 +112,7 @@ describe('Provider', () => {
           duration: '00:55',
           thumbnailUrl: 'youtube:thumbnailUrl',
           playerUrl: 'youtube:playerUrl',
-          metadata: '<iframe src=youtube:playerUrl frameborder="0"></iframe>',
+          metadata: { embedCode: '<iframe src=youtube:playerUrl frameborder="0"></iframe>' },
           provider: 'youtube',
           providerVideoId: '10'
         });

--- a/test/providers/digiteka.js
+++ b/test/providers/digiteka.js
@@ -99,7 +99,7 @@ describe('Digiteka provider', () => {
           'surveillance de combattants anti-Assad, d’être évacuées en zone ' +
           'loyaliste, dans le cadre d’un accord d’échange.',
           duration: '00:49',
-          metadata: '<iframe src=//www.ultimedia.com/deliver/generic/iframe/mdtk/01637594/zone/34/src/8f3q8q frameborder="0"></iframe>',
+          metadata: { embedCode: '<iframe src=//www.ultimedia.com/deliver/generic/iframe/mdtk/01637594/zone/34/src/8f3q8q frameborder="0"></iframe>' },
           playerUrl: '//www.ultimedia.com/deliver/generic/iframe/mdtk/01637594/zone/34/src/8f3q8q',
           provider: 'digiteka',
           thumbnailUrl: '//medialb.ultimedia.com/multi/35fzl/8f3q8q-L.jpg',


### PR DESCRIPTION
Pour corriger : https://github.com/lemonde/cms/pull/5903/files#diff-a99bf230d2401fc4cb518be7aafd63cdL117

Clé attendue ici : https://github.com/lemonde/cms/blob/6d713d01b7c6042b79ecfdd8cb42bb2d384b611f/server/exports/formatters/sept/articles/transport.js#L201

"
Pour afficher cette vidéo, on vérifie si le champ LIV_VIDEO de la base Oracle est rempli. Si c'est le cas, on affiche son contenu à la place de l'image en haut du live. Ce champ est censé contenir le code embed du player vidéo. Le nom équivalent pour les models legacy c'est S_video.

Dans l'export du Huit, ce champ S_video correspond à une metadata embedCode de la video glissée dans le live.
"