### PR TITLE
fix(youtube): retire le memoize qui ne fonctionne pas correctement

### DIFF
--- a/lib/providers/youtube.js
+++ b/lib/providers/youtube.js
@@ -15,11 +15,11 @@ var fetchUrl = function fetchUrl(videoId, part) {
   return 'https://www.googleapis.com/youtube/v3/videos?part=' + part + '&id=' + videoId + '&key=' + provider.apiKey;
 };
 
-var fetchVideo = _.memoize(function (videoId, part) {
+var fetchVideo = function fetchVideo(videoId, part) {
   return fetch(fetchUrl(videoId, part), { headers: provider.headers }).then(function (res) {
     return res.json();
   });
-});
+};
 
 /**
  * Convert duration ISO 8601 to seconds


### PR DESCRIPTION
# Description
La durée des vidéos youtube n'est pas récupérée

# Spec technique
La fonction `_.memoize` utilisée pour wrapper le fetch à l'api youtube utilise uniquement le premier paramètre comme clé de son cache, les appels:  `fetchVideo(videoId, 'snippet')` et 
`fetchVideo(videoId, 'contentDetails')` retournaient alors le même résultat. Ce résultat ne contenait donc jamais la propriété `contentDetails`.

2 solutions:
 - retirer le `_.memoize`
 - utiliser le 2ème paramètre de `_.memoize` pour définir un `resolver` custom.

A première vu seul 2 appels identique sont effectués donc retirer le `_.memoize` ne devrait pas générer trop d'appels. (@JBustin)

