### PR TITLE
fix(youtube): retire le memoize qui ne fonctionne pas correctement (v2)

### DIFF
--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -11,10 +11,8 @@ const fetchUrl = (videoId, part) => (
   `https://www.googleapis.com/youtube/v3/videos?part=${part}&id=${videoId}&key=${provider.apiKey}`
 );
 
-const fetchVideo = _.memoize(
-  (videoId, part) => fetch(fetchUrl(videoId, part), { headers: provider.headers })
-    .then(res => res.json())
-);
+const fetchVideo = (videoId, part) => fetch(fetchUrl(videoId, part), { headers: provider.headers })
+    .then(res => res.json());
 
 /**
  * Convert duration ISO 8601 to seconds


### PR DESCRIPTION
suite de #5: Cette fois sur le fichier dans `src/` 