### PR TITLE
fix(youtube): retire le memoize qui ne fonctionne pas correctement (v3)

### DIFF
--- a/lib/providers/youtube.js
+++ b/lib/providers/youtube.js
@@ -33,11 +33,11 @@ var searchUrl = function searchUrl(query, token) {
   return url;
 };
 
-var fetchVideo = _.memoize(function (videoId, part) {
+var fetchVideo = function fetchVideo(videoId, part) {
   return fetch(fetchUrl(videoId, part), { headers: provider.headers }).then(function (res) {
     return res.json();
   });
-});
+};
 
 /**
  * Convert duration ISO 8601 to seconds

--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -29,9 +29,8 @@ const searchUrl = (query, token) => {
   return url;
 };
 
-const fetchVideo = _.memoize((videoId, part) =>
-  fetch(fetchUrl(videoId, part), { headers: provider.headers }).then(res => res.json())
-);
+const fetchVideo = (videoId, part) => fetch(fetchUrl(videoId, part), { headers: provider.headers })
+  .then(res => res.json());
 
 /**
  * Convert duration ISO 8601 to seconds


### PR DESCRIPTION
Retire a nouveau le `_.memoize`. #5 