### PR TITLE
chore(youtube): ajout du param order pour la recherche youtube

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,11 +70,16 @@ videoProvider.extendProvider('digiteka', {
 ```
 
 Digiteka provider has a `search` method to require in utlimedia catalog.
+Params :
+
+- pattern [required]
+- pageToken (youtube only)
+- order (youtube only)
 
 Youtube provider has a `search` method to search within youtube library. It returns an Object with 2 keys, one for the token for the next request, the second holds a videos collection matching the criteria:
 
 ```js
-// "converge" is you search
+// "converge" is your search
 const searcher = () => videoProvider.getProviderFromName('youtube').search(encodeURIComponent('converge'))
 
 searcher().then(data => console.log(data))
@@ -316,8 +321,8 @@ provider
 ## How to contribute ?
 
 Since `js-release` is included in the project, you can make a release with it:
-See the changelog: `yarn release -- changelog`
-make the release: `yarn release -- add <patch|minor|major>`
+See the changelog: `yarn release changelog`
+make the release: `yarn release add <patch|minor|major>`
 
 This will transpile the sources (`yarn build`) before creating a new release.
 

--- a/src/providers/youtube.js
+++ b/src/providers/youtube.js
@@ -11,7 +11,7 @@ const getUrl = videoId => `//www.youtube.com/embed/${videoId}`;
 const fetchUrl = (videoId, part) =>
   `https://www.googleapis.com/youtube/v3/videos?part=${part}&id=${videoId}&key=${provider.apiKey}`;
 
-const searchUrl = (query, token) => {
+const searchUrl = (query, token, order) => {
   let url;
   url =
     'https://www.googleapis.com/youtube/v3/search' +
@@ -24,6 +24,10 @@ const searchUrl = (query, token) => {
 
   if (token) {
     url = `${url}&pageToken=${token}`;
+  }
+
+  if (order) {
+    url = `${url}&order=${order}`;
   }
 
   return url;
@@ -113,9 +117,9 @@ const provider = {
         ]).join(' ')
       )
     ),
-  search: (query, token) => {
+  search: (query, token, order) => {
     const result = [];
-    return fetch(searchUrl(query, token), {
+    return fetch(searchUrl(query, token, order), {
       timeout: 10000,
       headers: provider.headers,
     })
@@ -135,7 +139,7 @@ const provider = {
             snippet: { title, description, thumbnails, publishedAt },
             contentDetails,
             player: { embedHtml },
-          } = _.get(item, 'items.0');
+          } = _.get(item, 'items.0', {});
           return formatter('youtube', id, {
             title,
             description,


### PR DESCRIPTION
```
order | string

The order parameter specifies the method that will be used to order resources in the API response. The default value is relevance.Acceptable values are:

date – Resources are sorted in reverse chronological order based on the date they were created.

rating – Resources are sorted from highest to lowest rating.

relevance – Resources are sorted based on their relevance to the search query. This is the default value for this parameter.

title – Resources are sorted alphabetically by title.

videoCount – Channels are sorted in descending order of their number of uploaded videos.

viewCount – Resources are sorted from highest to lowest number of views. For live broadcasts, videos are sorted by number of concurrent viewers while the broadcasts are ongoing.
```

https://developers.google.com/youtube/v3/docs/search/list